### PR TITLE
Add Invoice Dashboard project

### DIFF
--- a/Invoice-Dashboard/.gitignore
+++ b/Invoice-Dashboard/.gitignore
@@ -1,0 +1,10 @@
+__pycache__
+*.pyc
+*.pyo
+.env
+.venv
+.eggs
+*.egg-info
+.pytest_cache
+.dist
+build

--- a/Invoice-Dashboard/README.md
+++ b/Invoice-Dashboard/README.md
@@ -1,0 +1,58 @@
+# Invoice Dashboard
+
+Invoice Dashboard is a small Python project for summarizing invoice data. It loads invoice records from JSON and prints a human-friendly dashboard that highlights totals, outstanding balances, and overdue invoices.
+
+## Features
+- Load invoices from a JSON file.
+- Provide totals for issued, paid, and outstanding invoices.
+- Highlight overdue invoices with details and customer breakdowns.
+- Export summaries to a JSON report for further processing.
+
+## Quickstart
+1. Ensure Python 3.10+ is available.
+2. Install the project in editable mode:
+
+```bash
+cd Invoice-Dashboard
+pip install -e .
+```
+
+3. Run the dashboard against the sample data:
+
+```bash
+invoice-dashboard data/invoices.json
+```
+
+4. Write an exportable summary to disk:
+
+```bash
+invoice-dashboard data/invoices.json --export summary.json
+```
+
+## Data format
+Invoices are stored as a list of objects with the following fields:
+
+```json
+{
+  "id": "INV-1001",
+  "customer": "Acme Corp",
+  "amount": 1250.0,
+  "status": "paid",
+  "issued_on": "2024-09-01",
+  "due_on": "2024-09-15",
+  "paid_on": "2024-09-10"
+}
+```
+
+- `status` should be `paid`, `open`, or `overdue`.
+- `paid_on` is optional and only relevant for paid invoices.
+
+## Development
+Run the lightweight tests:
+
+```bash
+pytest
+```
+
+## License
+This project is licensed under the MIT License.

--- a/Invoice-Dashboard/data/invoices.json
+++ b/Invoice-Dashboard/data/invoices.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "INV-1001",
+    "customer": "Acme Corp",
+    "amount": 1250.00,
+    "status": "paid",
+    "issued_on": "2024-09-01",
+    "due_on": "2024-09-15",
+    "paid_on": "2024-09-10"
+  },
+  {
+    "id": "INV-1002",
+    "customer": "Globex",
+    "amount": 890.50,
+    "status": "open",
+    "issued_on": "2024-09-05",
+    "due_on": "2024-09-20"
+  },
+  {
+    "id": "INV-1003",
+    "customer": "Initech",
+    "amount": 2300.00,
+    "status": "overdue",
+    "issued_on": "2024-08-15",
+    "due_on": "2024-08-30"
+  },
+  {
+    "id": "INV-1004",
+    "customer": "Acme Corp",
+    "amount": 540.00,
+    "status": "open",
+    "issued_on": "2024-09-10",
+    "due_on": "2024-09-25"
+  }
+]

--- a/Invoice-Dashboard/pyproject.toml
+++ b/Invoice-Dashboard/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "invoice-dashboard"
+version = "0.1.0"
+description = "A lightweight CLI for summarizing invoice data"
+authors = [{ name = "OpenAI", email = "example@example.com" }]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.scripts]
+invoice-dashboard = "invoice_dashboard.dashboard:main"

--- a/Invoice-Dashboard/src/invoice_dashboard/__init__.py
+++ b/Invoice-Dashboard/src/invoice_dashboard/__init__.py
@@ -1,0 +1,1 @@
+"""Invoice Dashboard package."""

--- a/Invoice-Dashboard/src/invoice_dashboard/dashboard.py
+++ b/Invoice-Dashboard/src/invoice_dashboard/dashboard.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+
+@dataclass
+class Invoice:
+    id: str
+    customer: str
+    amount: float
+    status: str
+    issued_on: date
+    due_on: date
+    paid_on: date | None = None
+
+    @classmethod
+    def from_mapping(cls, payload: dict) -> "Invoice":
+        return cls(
+            id=str(payload["id"]),
+            customer=payload["customer"],
+            amount=float(payload["amount"]),
+            status=payload["status"],
+            issued_on=_parse_date(payload["issued_on"]),
+            due_on=_parse_date(payload["due_on"]),
+            paid_on=_parse_date(payload.get("paid_on")) if payload.get("paid_on") else None,
+        )
+
+    def is_paid(self) -> bool:
+        return self.status.lower() == "paid"
+
+    def is_overdue(self, today: date | None = None) -> bool:
+        if self.status.lower() == "overdue":
+            return True
+        if today is None:
+            return False
+        return self.status.lower() != "paid" and self.due_on < today
+
+
+@dataclass
+class DashboardSummary:
+    total_invoices: int
+    total_amount: float
+    paid_amount: float
+    outstanding_amount: float
+    overdue_invoices: List[Invoice]
+    customers: List[Tuple[str, float]]
+
+    def to_dict(self) -> dict:
+        return {
+            "total_invoices": self.total_invoices,
+            "total_amount": self.total_amount,
+            "paid_amount": self.paid_amount,
+            "outstanding_amount": self.outstanding_amount,
+            "overdue_count": len(self.overdue_invoices),
+            "overdue_invoices": [invoice.id for invoice in self.overdue_invoices],
+            "customers": self.customers,
+        }
+
+
+def _parse_date(value: str) -> date:
+    return date.fromisoformat(value)
+
+
+def load_invoices(path: Path) -> List[Invoice]:
+    with path.open() as handle:
+        raw = json.load(handle)
+    return [Invoice.from_mapping(item) for item in raw]
+
+
+def summarize_invoices(invoices: Iterable[Invoice]) -> DashboardSummary:
+    invoices_list = list(invoices)
+    total_amount = sum(invoice.amount for invoice in invoices_list)
+    paid_amount = sum(invoice.amount for invoice in invoices_list if invoice.is_paid())
+    outstanding_amount = total_amount - paid_amount
+
+    overdue = [invoice for invoice in invoices_list if invoice.is_overdue()]
+    customer_totals = _aggregate_by_customer(invoices_list)
+
+    return DashboardSummary(
+        total_invoices=len(invoices_list),
+        total_amount=total_amount,
+        paid_amount=paid_amount,
+        outstanding_amount=outstanding_amount,
+        overdue_invoices=overdue,
+        customers=customer_totals,
+    )
+
+
+def _aggregate_by_customer(invoices: Iterable[Invoice]) -> List[Tuple[str, float]]:
+    totals: dict[str, float] = {}
+    for invoice in invoices:
+        totals[invoice.customer] = totals.get(invoice.customer, 0.0) + invoice.amount
+    return sorted(totals.items(), key=lambda item: item[1], reverse=True)
+
+
+def print_dashboard(summary: DashboardSummary) -> None:
+    print("Invoice Dashboard")
+    print("================")
+    print(f"Total invoices: {summary.total_invoices}")
+    print(f"Total amount:   ${summary.total_amount:,.2f}")
+    print(f"Paid amount:    ${summary.paid_amount:,.2f}")
+    print(f"Outstanding:    ${summary.outstanding_amount:,.2f}")
+    print()
+    if summary.overdue_invoices:
+        print("Overdue Invoices:")
+        for invoice in summary.overdue_invoices:
+            print(
+                f"- {invoice.id} for {invoice.customer}: ${invoice.amount:,.2f} "
+                f"(due {invoice.due_on.isoformat()})"
+            )
+        print()
+    else:
+        print("No overdue invoices.\n")
+
+    print("Top customers by amount:")
+    for customer, total in summary.customers:
+        print(f"- {customer}: ${total:,.2f}")
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Summarize invoice data")
+    parser.add_argument("path", type=Path, help="Path to the invoices JSON file")
+    parser.add_argument("--export", type=Path, help="Optional path to write JSON summary")
+    args = parser.parse_args(argv)
+
+    invoices = load_invoices(args.path)
+    summary = summarize_invoices(invoices)
+
+    print_dashboard(summary)
+
+    if args.export:
+        args.export.write_text(json.dumps(summary.to_dict(), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/Invoice-Dashboard/tests/test_dashboard.py
+++ b/Invoice-Dashboard/tests/test_dashboard.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from invoice_dashboard.dashboard import load_invoices, summarize_invoices
+
+
+def test_summarize_sample_data():
+    sample_path = Path(__file__).parent.parent / "data" / "invoices.json"
+    invoices = load_invoices(sample_path)
+
+    summary = summarize_invoices(invoices)
+
+    assert summary.total_invoices == 4
+    assert summary.total_amount == 4980.5
+    assert summary.paid_amount == 1250
+    assert summary.outstanding_amount == 3730.5
+    assert len(summary.overdue_invoices) == 1
+    assert summary.overdue_invoices[0].id == "INV-1003"
+    assert summary.customers[0][0] == "Initech"


### PR DESCRIPTION
## Summary
- scaffold a new Invoice-Dashboard project with packaging metadata
- implement invoice summarization CLI with sample data and documentation
- add a unit test covering the sample invoice summary logic

## Testing
- PYTHONPATH=src pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ec84236f483258b37d278e71b3a0f)