### PR TITLE
Add Codex Playground area (dogmatica.playground)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Welcome to the **Dogmatica** repository. This project serves as a small tutorial
 
 ## Repository layout
 
-- `src/` – the source code for the `dogmatica` package.
+- `src/` – the source code for the `dogmatica` package (including a new playground helper under `dogmatica.playground`).
 - `tests/` – unit tests for the code in `src/`.
 - `docs/` – extra documentation and guides.
 - `.gitignore` – patterns for files Git should ignore.
@@ -35,3 +35,9 @@ Welcome to the **Dogmatica** repository. This project serves as a small tutorial
 
 Browse the files under `src/`, `tests/`, and `docs/` to see how a simple project is structured. Feel free to experiment—add new modules, write additional tests, or expand the documentation.
 
+
+
+## Playground area
+
+Dogmatica now includes a lightweight `Codex Playground` area exposed by `dogmatica.codex_playground()`.
+Use it as a starting point for small experiments and extend it with your own ideas over time.

--- a/src/dogmatica/__init__.py
+++ b/src/dogmatica/__init__.py
@@ -1,7 +1,8 @@
 """Dogmatica package."""
 
-__all__ = ["greet"]
+__all__ = ["greet", "codex_playground"]
 
 from .example import greet
+from .playground import codex_playground
 
 __version__ = "0.1.0"

--- a/src/dogmatica/playground.py
+++ b/src/dogmatica/playground.py
@@ -1,0 +1,16 @@
+"""Playground utilities for trying out ideas inside Dogmatica."""
+
+from __future__ import annotations
+
+
+def codex_playground() -> dict[str, str]:
+    """Return metadata describing a lightweight experimental area.
+
+    This function is intentionally simple: it defines a dedicated "playground"
+    concept that can be extended with additional experiments over time.
+    """
+    return {
+        "name": "Codex Playground",
+        "description": "A safe area for trying ideas, prompts, and experiments.",
+        "owner": "Codex",
+    }

--- a/tests/test_playground.py
+++ b/tests/test_playground.py
@@ -1,0 +1,9 @@
+from dogmatica import codex_playground
+
+
+def test_codex_playground_defaults():
+    playground = codex_playground()
+
+    assert playground["name"] == "Codex Playground"
+    assert playground["owner"] == "Codex"
+    assert "experiments" in playground["description"]


### PR DESCRIPTION
### Motivation

- Provide a lightweight experimental "playground" area inside the package for trying ideas, prompts, and small experiments.
- Make the playground available from the top-level API so it is easy to import and extend via `dogmatica.codex_playground`.

### Description

- Added `src/dogmatica/playground.py` implementing `codex_playground()` which returns simple metadata (`name`, `description`, `owner`).
- Exported `codex_playground` from `src/dogmatica/__init__.py` by updating `__all__` and adding the import. 
- Added `tests/test_playground.py` to validate the new playground defaults. 
- Updated `README.md` to mention the new playground helper and where to find it.

### Testing

- Ran `PYTHONPATH=src pytest -q tests/test_example.py tests/test_playground.py` which passed (`2 passed`).
- Ran `pytest -q` across the whole repository which failed due to unrelated multi-project import-path issues for other subprojects (e.g., `invoice_dashboard`), not because of the changes in `dogmatica`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698921ea95c883258d9b993a06178fb4)